### PR TITLE
missing perms dupe patch

### DIFF
--- a/src/main/java/com/james090500/VelocityGUI/helpers/InventoryClickHandler.java
+++ b/src/main/java/com/james090500/VelocityGUI/helpers/InventoryClickHandler.java
@@ -28,8 +28,11 @@ public class InventoryClickHandler {
             switch(splitCommand[0]) {
                 case "open":
                     click.player().registeredInventories().clear();
-                    new InventoryLauncher(velocityGUI).execute(splitCommand[1], player);
-                    break;
+
+                    if (!(new InventoryLauncher(velocityGUI).execute(splitCommand[1], player))) {
+                        ProtocolizePlayer protocolizePlayer = Protocolize.playerProvider().player(player.getUniqueId());
+                        protocolizePlayer.closeInventory();
+                    }
                 case "close":
                     click.player().closeInventory();
                     break;

--- a/src/main/java/com/james090500/VelocityGUI/helpers/InventoryLauncher.java
+++ b/src/main/java/com/james090500/VelocityGUI/helpers/InventoryLauncher.java
@@ -44,13 +44,13 @@ public class InventoryLauncher {
         inventoryBuilder.setEmpty(panel.getEmpty());
         inventoryBuilder.setItems(panel.getItems());
         Inventory inventory = inventoryBuilder.build();
-        inventory.onClick(click -> {
+        if (!returnState) {inventory.onClick(click -> {
             click.cancelled(true);
             Configs.Item item = panel.getItems().get(click.slot());
             if(item != null && item.getCommands() != null) {
                 new InventoryClickHandler(velocityGUI).execute(item.getCommands(), click);
             }
-        });
+        });}
 
         ProtocolizePlayer protocolizePlayer = Protocolize.playerProvider().player(player.getUniqueId());
         protocolizePlayer.openInventory(inventory);

--- a/src/main/java/com/james090500/VelocityGUI/helpers/InventoryLauncher.java
+++ b/src/main/java/com/james090500/VelocityGUI/helpers/InventoryLauncher.java
@@ -23,17 +23,19 @@ public class InventoryLauncher {
      * @param panelName
      * @param player
      */
-    public void execute(String panelName, Player player) {
+    public boolean execute(String panelName, Player player) {
         Configs.Panel panel = Configs.getPanels().get(panelName);
+        
+        boolean returnState = true;
         if(panel == null) {
             player.sendMessage(LegacyComponentSerializer.legacyAmpersand().deserialize(velocityGUI.PREFIX + "Panel not found"));
-            return;
+            return false;
         }
 
         //Stop players with no permissions
         if(!panel.getPerm().equalsIgnoreCase("default") && !player.hasPermission(panel.getPerm())) {
             player.sendMessage(LegacyComponentSerializer.legacyAmpersand().deserialize(velocityGUI.PREFIX + "Panel not found"));
-            return;
+            returnState = false;
         }
 
         InventoryBuilder inventoryBuilder = new InventoryBuilder(velocityGUI, player);
@@ -56,5 +58,7 @@ public class InventoryLauncher {
         if(panel.getSound() != null) {
             protocolizePlayer.playSound(Sound.valueOf(panel.getSound()), SoundCategory.MASTER, 1f, 1f);
         }
+        
+        returnState returnState;
     }
 }

--- a/src/main/java/com/james090500/VelocityGUI/helpers/InventoryLauncher.java
+++ b/src/main/java/com/james090500/VelocityGUI/helpers/InventoryLauncher.java
@@ -44,7 +44,7 @@ public class InventoryLauncher {
         inventoryBuilder.setEmpty(panel.getEmpty());
         inventoryBuilder.setItems(panel.getItems());
         Inventory inventory = inventoryBuilder.build();
-        if (!returnState) {inventory.onClick(click -> {
+        if (returnState) {inventory.onClick(click -> {
             click.cancelled(true);
             Configs.Item item = panel.getItems().get(click.slot());
             if(item != null && item.getCommands() != null) {


### PR DESCRIPTION
patch for preventing item duping with dead Inventorys, caused by closed event listener after missing perms. 